### PR TITLE
Allow for Gin theme and toolbar to update minor versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "drupal/events_logging": "1.4.0",
     "drupal/embed": "1.4.0",
     "drupal/gin": "^3.0",
+    "drupal/gin_toolbar": "^1.0",
     "drupal/header_and_footer_scripts": "2.2.0",
     "drupal/image_widget_crop": "2.3.0",
     "drupal/ldap": "^3.0@beta",


### PR DESCRIPTION
We are currently experiencing some compatibility issues where Gin theme version is set to 3.0.0-alpha33 and Gin toolbar version is 1.0.0-beta19.

This causes a compatibility issue and we can now better stay clear of breaking changes. 