### PR TITLE
Changed default page for flowdesigner

### DIFF
--- a/config/optional/user_default_page.user_default_page_config_entity.flowdesigner_default_page.yml
+++ b/config/optional/user_default_page.user_default_page_config_entity.flowdesigner_default_page.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   enforced:
     module:
-    - os2forms_forloeb
+      - os2forms_forloeb
 id: flowdesigner_default_page
 label: 'Flowdesigner default page'
 user_roles:
   flowdesigner: flowdesigner
 users: null
 weight: 1
-login_redirect: /maestro/templates/list
-login_redirect_message: 'Velkommen tilbage, her kan du arbejde med forløbsskabeloner.'
+login_redirect: /admin/structure/webform
+login_redirect_message: 'Velkommen tilbage, her kan du arbejde med webformularer.'
 logout_redirect: ''
 logout_redirect_message: ''


### PR DESCRIPTION
This is a draft, as the "flow-designer"-role doesn't have access to /admin/structure/webform at the moment. Question is, do we want it to?