### PR TITLE
Enable URL override for webform submissions and hashed url patterns

### DIFF
--- a/config/optional/pathauto.pattern.anonymous_submissions.yml
+++ b/config/optional/pathauto.pattern.anonymous_submissions.yml
@@ -1,0 +1,13 @@
+status: true
+dependencies:
+  module:
+  - ctools
+  - webform
+id: anonymous_submissions
+label: 'Anonymisering af indsendelser'
+type: 'canonical_entities:webform_submission'
+pattern: 'indsendelse/[random:hash:sha1]'
+selection_criteria: {  }
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/config/optional/pathauto.settings.yml
+++ b/config/optional/pathauto.settings.yml
@@ -1,2 +1,0 @@
-enabled_entity_types:
-- webform_submission

--- a/config/optional/pathauto.settings.yml
+++ b/config/optional/pathauto.settings.yml
@@ -1,0 +1,2 @@
+enabled_entity_types:
+- webform_submission


### PR DESCRIPTION
- URLs genereret til formularer-indsendelser hashes
- URLs til formularer-indsendelser  hashes automatisk og er tilgængelig for flowdesigner, selvbetjeningsdesigner, sagsbehandler eller leder
- En specifik hashed URL er tilgængelig for brug i templates, så den kan benyttes af handlers - `[webform_submission:url]`er den benyttede token
