### PR TITLE
[#46800] Adding MaestroWebformInherit to os2forms_forloeb.module

### DIFF
--- a/os2forms_forloeb.module
+++ b/os2forms_forloeb.module
@@ -200,7 +200,7 @@ function os2forms_forloeb_form_alter(&$form, FormStateInterface $form_state, $fo
   if ($isMaestro && $queueID) {
     $templateTask = MaestroEngine::getTemplateTaskByQueueID($queueID);
     // We only care about Maestro Webform Multiple tasks.
-    if ($templateTask && $templateTask['tasktype'] == 'MaestroWebformMultiple') {
+    if ($templateTask && ($templateTask['tasktype'] == 'MaestroWebformMultiple' || $templateTask['tasktype'] == 'MaestroWebformInherit')) {
       $storage = $form_state->getStorage();
       if ($storage && array_key_exists('form_display', $storage)) {
         $webformTypes = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();

--- a/os2forms_forloeb.module
+++ b/os2forms_forloeb.module
@@ -186,11 +186,20 @@ function os2forms_forloeb_spv_fetch_entity_username($uniqueWebformIdentifier, $w
 }
 
 /**
+ * Returns array of custom task-types for OS2forms
+ * 
+ */
+function os2forms_forloeb_get_custom_task_types() {
+  return ['MaestroWebformMultiple', 'MaestroWebformInherit'];
+}
+
+/**
  * Implements hook_form_alter() for MaestroWebformMultiple task type.
  *
  * This has been copied from
  * maestro/maestro_webform/maestro_webform.module with a minimal but
  * necessary change. See https://www.drupal.org/project/maestro/issues/3243510
+ * When that issue has been fixed, this hook implementation can be safely deleted.
  *
  */
 function os2forms_forloeb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -199,8 +208,10 @@ function os2forms_forloeb_form_alter(&$form, FormStateInterface $form_state, $fo
   // Both these keys need to exist.
   if ($isMaestro && $queueID) {
     $templateTask = MaestroEngine::getTemplateTaskByQueueID($queueID);
-    // We only care about Maestro Webform Multiple tasks.
-    if ($templateTask && ($templateTask['tasktype'] == 'MaestroWebformMultiple' || $templateTask['tasktype'] == 'MaestroWebformInherit')) {
+    // Get array of custom task-types
+    $os2forms_forloeb_custom_task_types = os2forms_forloeb_get_custom_task_types();
+    // We only care about custom Task-types defined in os2forms_forloeb_get_custom_task_types()
+    if ($templateTask && in_array($templateTask['tasktype'], $os2forms_forloeb_custom_task_types)) {
       $storage = $form_state->getStorage();
       if ($storage && array_key_exists('form_display', $storage)) {
         $webformTypes = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();


### PR DESCRIPTION
This change is needed for the user to be able to use the maestro task 'WebformInherit'.

Attached webforms and flow for test.

[hjemmearbejde_flow.txt](https://github.com/OS2Forms/os2forms_forloeb/files/7632728/hjemmearbejde_flow.txt)
[Aftale om hjemmearbejde.txt](https://github.com/OS2Forms/os2forms_forloeb/files/7632729/Aftale.om.hjemmearbejde.txt)
[AMR vurdering.txt](https://github.com/OS2Forms/os2forms_forloeb/files/7632730/AMR.vurdering.txt)
[Samlet leder.txt](https://github.com/OS2Forms/os2forms_forloeb/files/7632731/Samlet.leder.txt)
[Samlet leder 2.txt](https://github.com/OS2Forms/os2forms_forloeb/files/7632732/Samlet.leder.2.txt)
