### PR TITLE
Updating version of coc_forms_auto_export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "drupal/chosen": "2.10.0",
     "drupal/ckeditor_a11ychecker": "1.0.0",
     "drupal/clientside_validation": "3.0.0-rc4",
-    "drupal/coc_forms_auto_export": "1.0.0-alpha1",
+    "drupal/coc_forms_auto_export": "2.0.0-alpha1",
     "drupal/config_entity_revisions": "1.7.0",
     "drupal/events_logging": "1.4.0",
     "drupal/embed": "1.4.0",


### PR DESCRIPTION
Webform 5 is currently an unsupported version of Webform.
Due to that OS2Forms project need to get update to Webform v6

To be able to update OS2Forms project to Webform 6 we need to have coc_forms_auto_export updated to a higher version

See for more information https://www.drupal.org/sa-contrib-2021-045