### PR TITLE
Add gin-custom.css to repo.

### DIFF
--- a/css/gin-custom.css
+++ b/css/gin-custom.css
@@ -1,0 +1,3 @@
+.ui-dialog:not(.ui-dialog-off-canvas) {
+    width: 70vw!important;
+}

--- a/os2forms_forloeb.libraries.yml
+++ b/os2forms_forloeb.libraries.yml
@@ -1,5 +1,7 @@
-gin-custom-styles:
+os2forms_forloeb:
   version: 1.x
   css:
     theme:
       css/gin-custom.css: {}
+  dependencies:
+    - drupal/gin

--- a/os2forms_forloeb.libraries.yml
+++ b/os2forms_forloeb.libraries.yml
@@ -1,0 +1,5 @@
+gin-custom-styles:
+  version: 1.x
+  css:
+    theme:
+      css/gin-custom.css: {}

--- a/os2forms_forloeb.module
+++ b/os2forms_forloeb.module
@@ -264,3 +264,7 @@ function os2forms_forloeb_form_alter(&$form, FormStateInterface $form_state, $fo
     }
   }
 }
+
+function os2forms_forloeb_preprocess_page(&$variables) {
+    $variables['#attached']['library'][] = 'os2forms_forloeb/os2forms_forloeb';
+}


### PR DESCRIPTION
We had this custom css file in our distribution repo and it shouldn't "live" there. By doing this we can centralise the benefits and availability of custom css changes to Gin theme and in turn OS2forms Forløb. 

