### PR TITLE
Remove dependencies block to fix missing theme error

### DIFF
--- a/os2forms_forloeb.libraries.yml
+++ b/os2forms_forloeb.libraries.yml
@@ -3,5 +3,3 @@ os2forms_forloeb:
   css:
     theme:
       css/gin-custom.css: {}
-  dependencies:
-    - drupal/gin


### PR DESCRIPTION
Fixes following warning:
`Warning: User warning: The following theme is missing from the file system: drupal`

I have tested the fix locally and removing the declaration of the `dependencies` block does not introduce any breaking changes.