### PR TITLE
Task A: Implemented redirect route for task console to get better UX for users

### DIFF
--- a/os2forms_forloeb.routing.yml
+++ b/os2forms_forloeb.routing.yml
@@ -1,5 +1,5 @@
 os2forms_forloeb.forloeb_task_console_controller_execute:
-  path: 'execute-foloeb-task'
+  path: 'os2forms-forloeb/execute-task'
   defaults:
     _controller: '\Drupal\os2forms_forloeb\Controller\ForloebTaskConsoleController::execute'
     _title: 'Execute task'

--- a/os2forms_forloeb.routing.yml
+++ b/os2forms_forloeb.routing.yml
@@ -1,0 +1,9 @@
+os2forms_forloeb.forloeb_task_console_controller_execute:
+  path: 'execute-foloeb-task'
+  defaults:
+    _controller: '\Drupal\os2forms_forloeb\Controller\ForloebTaskConsoleController::execute'
+    _title: 'Execute task'
+  requirements:
+    _permission: 'view maestro task console'
+  options:
+    no_cache: TRUE

--- a/os2forms_forloeb.services.yml
+++ b/os2forms_forloeb.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.channel.os2forms_forloeb:
+    parent: logger.channel_base
+    arguments: ['os2forms_forloeb']
+  os2forms_forloeb.task_console:
+    class: Drupal\os2forms_forloeb\ForloebTaskConsole
+    arguments: ['@entity_type.manager']

--- a/src/Controller/ForloebTaskConsoleController.php
+++ b/src/Controller/ForloebTaskConsoleController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\os2forms_forloeb\Controller;
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\maestro\Engine\MaestroEngine;
+use Drupal\maestro\Utility\TaskHandler;
+use Drupal\os2forms_forloeb\ForloebTaskConsole;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Class ForloebTaskConsoleController.
+ */
+class ForloebTaskConsoleController extends ControllerBase {
+
+  /**
+   * Update manager service.
+   *
+   * @var \Drupal\os2forms_forloeb\ForloebTaskConsole
+   */
+  protected $forloebTaskConsole;
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs update status data.
+   *
+   * @param \Drupal\os2forms_forloeb\ForloebTaskConsole $forloebTaskConsole
+   *   Forloeb task console Service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The Entity type manager.
+   */
+  public function __construct(ForloebTaskConsole $forloeb_task_console, EntityTypeManagerInterface $entity_type_manager) {
+    $this->forloebTaskConsole = $forloeb_task_console;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('os2forms_forloeb.task_console'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Redirects to the task execution URL.
+   *
+   * In case it's not possible to define task, redirects to task console.
+   *
+   * @return RedirectResponse
+   *   Redirect object.
+   */
+  public function execute() {
+    $redirect_to = Url::fromRoute('maestro_taskconsole.taskconsole');
+
+    // Check webform submission token.
+    $token = \Drupal::request()->query->get('token', '');
+    if ($token) {
+      $queueRecord = $this->forloebTaskConsole->getQueueIdByWebformSubmissionToken($token);
+    }
+    else {
+      // For empty token there is user last task from taskconsole queue.
+      $queueIDs = MaestroEngine::getAssignedTaskQueueIds(\Drupal::currentUser()->id());
+      $queueRecord = count($queueIDs) ? $this->entityTypeManager->getStorage('maestro_queue')->load(end($queueIDs)) : NULL;
+
+      // In case there are more than 1 task warning message will be shown.
+      if (count($queueIDs) > 1) {
+        $this->messenger()->addWarning($this->t('You have @amount @tasks available for you. See list of the all tasks on <a href=":tasksonsole">taskconsole</a>', [
+          ':tasksonsole' => Url::fromRoute('maestro_taskconsole.taskconsole')->toString(),
+          '@amount' => count($queueIDs),
+          '@tasks' => new PluralTranslatableMarkup(count($queueIDs), 'task','tasks'),
+        ]));
+      }
+    }
+
+    // Processing QueueRecord to get execution URL to redirect to.
+    if ($queueRecord) {
+      $handler = $queueRecord->handler->getString();
+      $query_options = [
+        'queueid' => $queueRecord->id(),
+        'modal' => 'notmodal'
+      ];
+
+      // As inspiration MaestroTaskConsoleController::getTasks() method was used.
+      if ($handler && !empty($handler) && $queueRecord->is_interactive->getString() == '1') {
+        global $base_url;
+        $handler = str_replace($base_url, '', $handler);
+        $handler_type = TaskHandler::getType($handler);
+
+        $handler_url_parts = UrlHelper::parse($handler);
+        $query_options += $handler_url_parts['query'];
+
+      }
+      elseif ($queueRecord->is_interactive->getString() == '1' && empty($handler)) {
+        // Handler is empty. If this is an interactive task and has no handler, we're still OK.  This is an interactive function that uses a default handler then.
+        $handler_type = 'function';
+      }
+      else {
+        $this->messenger()->addWarning($this->t('Undefined handler'));
+      }
+
+      switch ($handler_type) {
+        case 'external':
+          $redirect_to =  Url::fromUri($handler, ['query' => $query_options]);
+          break;
+
+        case 'internal':
+          $redirect_to = Url::fromUserInput($handler, ['query' => $query_options]);
+          break;
+
+        case 'function':
+          $redirect_to = Url::fromRoute('maestro.execute', $query_options);
+          break;
+      }
+    }
+    else {
+      $this->messenger()->addWarning($this->t('No tasks found to execute.'));
+    }
+
+    return new RedirectResponse($redirect_to->toString());
+  }
+
+}

--- a/src/ForloebTaskConsole.php
+++ b/src/ForloebTaskConsole.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\os2forms_forloeb;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\maestro\Engine\MaestroEngine;
+use Drupal\webform\Entity\WebformSubmission;
+
+/**
+ * Class ForloebTaskConsole.
+ */
+class ForloebTaskConsole {
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new ForloebTaskConsole object.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Gets MaestroQueue record by webforms submission token.
+   *
+   * @param string $token
+   *
+   * @return \Drupal\maestro\Entity\MaestroQueue|null
+   *   Returns MaestroQueue entity or NULL
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getQueueIdByWebformSubmissionToken($token = '') {
+    $engine = new MaestroEngine();
+    // Fetch the user's queue items.
+    $queueIDs = $engine->getAssignedTaskQueueIds(\Drupal::currentUser()->id());
+
+    foreach ($queueIDs as $queueID) {
+      $this->entityTypeManager->getStorage('maestro_queue')->resetCache([$queueID]);
+      /** @var \Drupal\maestro\Entity\MaestroQueue $queueRecord */
+      $queueRecord = $this->entityTypeManager->getStorage('maestro_queue')->load($queueID);
+      $processID = $engine->getProcessIdFromQueueId($queueID);
+      $templateMachineName = $engine->getTemplateIdFromProcessId($processID);
+
+      // Get user input from 'inherit_webform_unique_id'
+      $taskMachineName = $engine->getTaskIdFromQueueId($queueID);
+      $task = $engine->getTemplateTaskByID($templateMachineName, $taskMachineName);
+
+      // Load its corresponding webform submission.
+      $sid = $engine->getEntityIdentiferByUniqueID($processID, $task['data']['inherit_webform_unique_id'] ?? '');
+      $webform_submission = $sid ? WebformSubmission::load($sid) : NULL;
+
+      if ($webform_submission && $webform_submission->getToken() != $token) {
+        return $queueRecord;
+      }
+    }
+
+    return NULL;
+  }
+}

--- a/src/ForloebTaskConsole.php
+++ b/src/ForloebTaskConsole.php
@@ -55,7 +55,8 @@ class ForloebTaskConsole {
       $sid = $engine->getEntityIdentiferByUniqueID($processID, $task['data']['inherit_webform_unique_id'] ?? '');
       $webform_submission = $sid ? WebformSubmission::load($sid) : NULL;
 
-      if ($webform_submission && $webform_submission->getToken() != $token) {
+      // Compare webform submission with token from request.
+      if ($webform_submission && $webform_submission->getToken() == $token) {
         return $queueRecord;
       }
     }


### PR DESCRIPTION
Custom path: `/execute-foloeb-task`

The ability to refer to the specific task in email is possible via token, for example 
`/execute-foloeb-task?token=XebF7BbNosDZNM-GNDP7ADH0vaPbR74pLSf8pnXCalE`

The code is available for testing as a composer package https://packagist.org/packages/os2forms/os2forms_forloeb#dev-AARHUS-ITK-A