### PR TITLE
Removed use of \Drupal call

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,5 +1,5 @@
-name: Check Code standards
-on: [push]
+name: Check coding standards
+on: pull_request
 jobs:
   coding-standards:
     name: PHP - Check Coding Standards

--- a/src/Controller/ForloebTaskConsoleController.php
+++ b/src/Controller/ForloebTaskConsoleController.php
@@ -81,14 +81,15 @@ class ForloebTaskConsoleController extends ControllerBase {
   public function execute() {
     $redirect_to = Url::fromRoute('maestro_taskconsole.taskconsole');
 
+    $request = $this->requestStack->getCurrentRequest();
     // Check webform submission token.
-    $token = $this->requestStack->getCurrentRequest()->query->get('os2forms-forloeb-ws-token', '');
+    $token = $request->query->get('os2forms-forloeb-ws-token', '');
     if ($token) {
       $queueRecord = $this->forloebTaskConsole->getQueueIdByWebformSubmissionToken($token);
       if (empty($queueRecord)) {
         return new RedirectResponse(
           Url::fromRoute('os2forms_forloeb.forloeb_task_console_controller_execute_retry',
-          ['referrer' => \Drupal::request()->getRequestUri()])->toString()
+          ['referrer' => $request->getRequestUri()])->toString()
         );
       }
     }


### PR DESCRIPTION
Replaces use of `\Drupal::request()` with use of the request from the already injected request stack.
