### PR TITLE
Composer cleanup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,4 +16,4 @@ jobs:
         run: git fetch
 
       - name: Check that changelog has been updated.
-        run: git diff --exit-code origin/develop -- CHANGELOG.md && exit 1 || exit 0
+        run: git diff --exit-code origin/${{ github.base_ref }} -- CHANGELOG.md && exit 1 || exit 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+on: pull_request
+name: Review
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    name: Changelog should be updated
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Git fetch
+        run: git fetch
+
+      - name: Check that changelog has been updated.
+        run: git diff --exit-code origin/develop -- CHANGELOG.md && exit 1 || exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See ["how do I make a good changelog record?"](https://keepachangelog.com/en/1.0
 before starting to add changes.
 
 ## [Unreleased]
+- Added github action for checking changelog changes when creating pull requests
+- Added os2forms/os2forms dependency
+- Changed composer patching configuration
+- Removed patches that don't belong in this project (Patched correctly in os2forms/os2forms project)
+- Added patch for drupal/dynamic_entity_reference
 
 ## 2.5.0 - 11.10.2022
 

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
       }
     },
     "branch-alias": {
-      "dev-composer_cleanup": "2.6.0"
+      "dev-composer_cleanup": "2.6.x-dev"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,6 @@
       "drupal/coc_forms_auto_export": {
         "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch"
       }
-    },
-    "branch-alias": {
-      "dev-composer_cleanup": "2.6.0"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
       }
     },
     "branch-alias": {
-      "dev-composer_cleanup": "2.6.x-dev"
+      "dev-composer_cleanup": "2.6.0"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "drupal/webform_scheduled_tasks": "^2.0",
     "drupal/webform_views": "^5.0@alpha",
     "drupal/workflow_participants": "^2.4",
-    "os2forms/os2forms": "^3.4",
+    "os2forms/os2forms": "^3.3",
     "webmozart/path-util": "^2.3",
     "zaporylie/composer-drupal-optimizations": "^1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -61,25 +61,16 @@
   },
   "extra": {
     "composer-exit-on-patch-failure": true,
-    "patchLevel": {
-      "test": "-p2"
-    },
     "enable-patching": true,
-    "patcher": {
-      "force-reset": true
-    },
     "patches": {
-      "drupal/entity_print": {
-        "2733781 - Add Export to Word Support": "https://www.drupal.org/files/issues/2019-11-22/2733781-47.patch"
-      },
-      "drupal/webform": {
-        "Unlock possibility of using Entity print module export to Word": "https://www.drupal.org/files/issues/2020-02-29/3096552-6.patch"
-      },
       "drupal/user_default_page": {
         "Warning: in_array() expects parameter 2 to be array, null given in user_default_page_user_logout() (https://www.drupal.org/node/3246986)": "https://www.drupal.org/files/issues/2021-11-01/user_default_page-3246986-2.patch"
       },
       "drupal/coc_forms_auto_export": {
         "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch"
+      },
+      "drupal/dynamic_entity_reference": {
+        "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038) - required by drupal/workflow_participants": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "drupal/webform_scheduled_tasks": "^2.0",
     "drupal/webform_views": "^5.0@alpha",
     "drupal/workflow_participants": "^2.4",
+    "os2forms/os2forms": "^3.4",
     "webmozart/path-util": "^2.3",
     "zaporylie/composer-drupal-optimizations": "^1.2"
   },
@@ -80,6 +81,9 @@
       "drupal/coc_forms_auto_export": {
         "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch"
       }
+    },
+    "branch-alias": {
+      "dev-composer_cleanup": "2.6.0"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -69,8 +69,9 @@
       "drupal/coc_forms_auto_export": {
         "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch"
       },
+      "//": "Note: drupal/dynamic_entity_reference is required by drupal/workflow_participants",
       "drupal/dynamic_entity_reference": {
-        "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038) - required by drupal/workflow_participants": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
+        "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038)": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
       }
     }
   },


### PR DESCRIPTION
https://os2web.atlassian.net/browse/OS2FORMS-389

- Added github action for checking changelog changes when creating pull requests
- Updated readme
- Removed webform_embed from repositories
- Removed array keys from repositories list
- Updated drupal core dependency
- Updated gin dependency
- Updated os2forms dependency
- Updated os2forms_forloeb dependency
- Added cweagans/composer-patches as dependency
- Removed drupal/dynamic_entity_reference (It belongs in os2forms/os2forms_forloeb)
- Changed composer patching configuration

Relates to https://github.com/OS2Forms/os2forms/pull/36 and https://github.com/OS2Forms/os2forms_forloeb_profile/pull/50