### PR TITLE
Bumped drupal ultimate_cron version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ before starting to add changes.
 
 ## [Unreleased]
 
+### Updated
+- Bumped drupal/ultimate_cron version fixing [Deprecated function: Implicit conversion from float-string](https://www.drupal.org/project/ultimate_cron/issues/3256142). 
+
 ## 2.5.1 - 10.03.2023
 - Added github action for checking changelog changes when creating pull requests
 - Added os2forms/os2forms dependency

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "drupal/simplesamlphp_auth": "^3.2",
     "drupal/switch_page_theme": "1.x-dev#ac38137f43cc72a8efba04bc127b87fbf2c28e06",
     "drupal/telephone_validation": "^2.2",
-    "drupal/ultimate_cron": "2.0.0-alpha5",
+    "drupal/ultimate_cron": "2.0.0-alpha6",
     "drupal/user_default_page": "^2.1",
     "drupal/webform_composite": "1.0-rc2",
     "drupal/webform_node_element": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "drupal/simplesamlphp_auth": "^3.2",
     "drupal/switch_page_theme": "1.x-dev#ac38137f43cc72a8efba04bc127b87fbf2c28e06",
     "drupal/telephone_validation": "^2.2",
-    "drupal/ultimate_cron": "2.0.0-alpha6",
+    "drupal/ultimate_cron": "^2.0.0",
     "drupal/user_default_page": "^2.1",
     "drupal/webform_composite": "1.0-rc2",
     "drupal/webform_node_element": "^1.2",


### PR DESCRIPTION
* Bumped `drupal/ultimate_cron ` version from `2.0.0-alpha5` to `^2.0.0` allowing newest `2.0.0-alpha6` version.